### PR TITLE
Needs GHC >= 7.6 due to Prelude.catch conflict

### DIFF
--- a/etcd.cabal
+++ b/etcd.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:   Network.Etcd
 
   build-depends:     aeson
-  build-depends:     base >= 4.0 && < 5
+  build-depends:     base >= 4.6 && < 5
   build-depends:     bytestring
   build-depends:     http-conduit
   build-depends:     time


### PR DESCRIPTION
I've revised current versions (http://hackage.haskell.org/package/etcd-1.0.5/revisions/) so a new release is only required if you want to support older GHCs.
